### PR TITLE
Try to use Promo Codes and Referrals for Rewardful

### DIFF
--- a/environment.d.ts
+++ b/environment.d.ts
@@ -23,6 +23,9 @@ declare global {
 	interface Window {
     dataLayer: any[];
 		rewardful: RewardfulStatic;
+		Rewardful: {
+			referral: string
+		}
     _rwq: any[];
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,11 +10,17 @@ import { mergeOpenGraph } from '@/lib/mergeOpenGraph';
 import StyledComponentsRegistry from '@/lib/registry';
 
 import 'aos/dist/aos.css';
-import 'slick-carousel/slick/slick.css';
-import 'slick-carousel/slick/slick-theme.css';
 import 'react-datepicker/dist/react-datepicker.css';
+import 'slick-carousel/slick/slick-theme.css';
+import 'slick-carousel/slick/slick.css';
 import './globals.css';
 import './main.css';
+
+// Use your Rewardful API Key
+const API_KEY = process.env.NEXT_PUBLIC_REWARDFUL_API_KEY || '642d4d';
+
+// If not setting NEXT_PUBLIC_APP_REWARDFUL_SCRIPT_URL, just use https://r.wdfl.co/rw.js
+const SCRIPT_URL = process.env.NEXT_PUBLIC_APP_REWARDFUL_SCRIPT_URL || 'https://r.wdfl.co/rw.js';
 
 export const metadata: Metadata = {
 	title: 'Geviti',
@@ -73,17 +79,13 @@ const RootLayout: React.FC<{ children: React.ReactNode; }> = ({ children }) => {
 						/>
 					</noscript>
 					<Script
-						id='rewardful_func'
-						strategy='beforeInteractive'>
-						{ `(function(w,r){w._rwq=r;w[r]=w[r]||function(){(w[r].q=w[r].q|| 
-    				[]).push(arguments)}})(window,'rewardful');` }
-					</Script>
-
+						src={ SCRIPT_URL }
+						data-rewardful={ API_KEY } />
 					<Script
-						id='rewardful_api'
-						strategy='beforeInteractive'
-						src='https://r.wdfl.co/rw.js'
-						data-rewardful='642d4d'  />
+						id='rewardful-queue'
+						strategy='beforeInteractive'>
+						{`(function(w,r){w._rwq=r;w[r]=w[r]||function(){(w[r].q=w[r].q||[]).push(arguments)}})(window,'rewardful');`}
+					</Script>
 				</body>
 			</StyledComponentsRegistry>
 		</html>

--- a/src/components/Checkout/StripeCheckout/StripeCheckout.tsx
+++ b/src/components/Checkout/StripeCheckout/StripeCheckout.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React, { FC, useCallback, useEffect, useState } from 'react';
-import { AiFillCloseCircle } from 'react-icons/ai';
 import { useRouter } from 'next/navigation';
+import { FC, useCallback, useEffect, useState } from 'react';
+import { AiFillCloseCircle } from 'react-icons/ai';
 import { toast } from 'sonner';
 
 // import MicroscopeIcon from '@/components/Icons/MicroscopeIcon';
@@ -14,9 +14,6 @@ import {
 	// checkout,
 	getAllProducts,
 	getDiscount,
-	// getInitialOfferings,
-	// getMembershipOfferings,
-	// getProductsPrice,
 } from '../api/onboarding';
 import {
 	DiscountReturnType,
@@ -60,6 +57,7 @@ const StripeCheckout: FC<PageProps> = ({ searchParams }) => {
 	const [discount, setDiscount] = useState<DiscountReturnType | null>(null);
 	const [totalPrice, setTotalPrice] = useState<number>();
 	const [discountApplied, setDiscountApplied] = useState(false);
+	const [promoCode, setPromoCode] = useState('');
 
 	useEffect(() => {
 		// setProductLoading(true);
@@ -92,8 +90,10 @@ const StripeCheckout: FC<PageProps> = ({ searchParams }) => {
 				setDiscount(couponDiscount);
 				if (couponDiscount?.id) {
 					setDiscountApplied(true);
+					setPromoCode(() => code);
 				} else {
 					setDiscountApplied(false);
+					setPromoCode(() => '');
 					toast.error('Coupon doesn\'t exist', {
 						icon: <AiFillCloseCircle className='h-5 w-5 text-danger' />,
 					});
@@ -102,6 +102,7 @@ const StripeCheckout: FC<PageProps> = ({ searchParams }) => {
 				setCouponLoading(false);
 			} catch (error) {
 				setDiscount(null);
+				setPromoCode('');
 				setDiscountApplied(false);
 				// setLoading(false);
 				setCouponLoading(false);
@@ -189,7 +190,7 @@ const StripeCheckout: FC<PageProps> = ({ searchParams }) => {
 				});
 			}
 		},
-		[product, discount]
+		[product, discount, promoCode]
 	);
 	return (
 		<div className='flex flex-col lg:flex-row min-h-screen h-full w-full font-Poppins'>
@@ -263,7 +264,7 @@ const StripeCheckout: FC<PageProps> = ({ searchParams }) => {
 								loading={ checkoutLoading }
 								totalPrice={ totalPrice }
 								handleCheckout={ handleCheckout }
-								coupon={ discount?.id ?? '' }
+								coupon={ discount?.id && promoCode ? promoCode : '' }
 								selectedProduct={ productSelected }
 								priceId={ priceId }
 							/>
@@ -273,7 +274,7 @@ const StripeCheckout: FC<PageProps> = ({ searchParams }) => {
 			</div>
 			<div className='h-full w-full bg-white max-lg:hidden'>
 				<StripeElementsProvider
-					coupon={ discount?.id ?? '' }
+					coupon={ discount?.id && promoCode ? promoCode : '' }
 					loading={ checkoutLoading }
 					totalPrice={ totalPrice }
 					handleCheckout={ handleCheckout }

--- a/src/components/Checkout/StripeCheckout/StripeCheckout.tsx
+++ b/src/components/Checkout/StripeCheckout/StripeCheckout.tsx
@@ -90,7 +90,7 @@ const StripeCheckout: FC<PageProps> = ({ searchParams }) => {
 				setDiscount(couponDiscount);
 				if (couponDiscount?.id) {
 					setDiscountApplied(true);
-					setPromoCode(() => code);
+					setPromoCode(() => code.toUpperCase());
 				} else {
 					setDiscountApplied(false);
 					setPromoCode(() => '');

--- a/src/components/Checkout/StripeCheckout/StripeForm.tsx
+++ b/src/components/Checkout/StripeCheckout/StripeForm.tsx
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, {
-	FC, useEffect, useMemo, useRef, useState
-} from 'react';
-import  Autocomplete from 'react-google-autocomplete';
 import InputMask from '@mona-health/react-input-mask';
 import { Elements, } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import { FormikProps, useFormik } from 'formik';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import React, {
+	FC, useEffect, useMemo, useRef, useState
+} from 'react';
+import Autocomplete from 'react-google-autocomplete';
 import { toast } from 'sonner';
 
 import { Dialog, DialogContent } from '@/components/Dialog';
@@ -68,6 +68,7 @@ const StripeForm: FC<StripeFormProps> = ({
 	const [isOpenDialogState, setIsOpenDialogState] = useState(false);
 	const [isOpenDialogNotAvailableState, setIsOpenDialogNotAvailableState] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
+	const [referral, setReferral] = useState('')
 
 	const formLoading = useMemo(
 		() => stripeResponseLoading || loading,
@@ -121,6 +122,7 @@ const StripeForm: FC<StripeFormProps> = ({
 							zipCode: form.zip_code
 						},
 						coupon: coupon,
+						referral: referral.length ? referral : undefined,
 						product: selectedProduct.map(product => {
 							return {
 								productId: product.stripeProductId,
@@ -218,6 +220,12 @@ const StripeForm: FC<StripeFormProps> = ({
 			toast.error('An error occurred');
 		}
 	}
+
+	useEffect(() => {
+		window.rewardful('ready', function() {
+			setReferral(window.Rewardful.referral);
+		});
+	}, []);
 
 	return (
 		<form

--- a/src/components/Checkout/api/types.ts
+++ b/src/components/Checkout/api/types.ts
@@ -200,6 +200,7 @@ export interface CreateSessionParams {
     zipCode: string;
   };
   coupon: string;
+  referral?: string;
   product: {
     productId: string;
     productName: string;


### PR DESCRIPTION
This PR tries to make 2 changes:

1. Use the entered Coupon value directly instead of the associated Coupon's ID. This is because Rewardful needs the actual Promo Code used to track it properly. 
2. Try to use the Referrals from the Rewardful SDK / library and pass the `referral` UUID value to the backend during the Checkout API call in the `referral` param, which can take a **string** or be **undefined**.